### PR TITLE
Enable Magick++

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -37,7 +37,7 @@ fi
             --with-lqr=no \
             --with-ltdl=no \
             --with-lzma=yes \
-            --with-magick-plus-plus=no \
+            --with-magick-plus-plus=yes \
             --with-openexr=no \
             --with-openjp2=yes \
             --with-pango=yes \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: af19f240f8fa2c3ba9e35238984332ce246d9ba8cf4535e8564624f57246e64d
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win]
 
 requirements:


### PR DESCRIPTION
Certain packages, [such as](https://github.com/conda-forge/staged-recipes/pull/4613#issuecomment-351430370) `r-magic`, require Magick++.

From http://www.imagemagick.org/Magick++/:

> Magick++ is the object-oriented C++ API to the ImageMagick image-processing library
