### PR TITLE
Glib 2.64 migration

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,8 +11,7 @@ jobs:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
-    maxParallel: 8
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
   timeoutInMinutes: 360
 
   steps:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -11,7 +11,6 @@ jobs:
       osx_64_:
         CONFIG: osx_64_
         UPLOAD_PACKAGES: 'True'
-    maxParallel: 8
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -25,7 +25,7 @@ freetype:
 giflib:
 - '5.2'
 glib:
-- '2.58'
+- 2.64.6
 graphviz:
 - '2.40'
 jpeg:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -3,7 +3,9 @@ bzip2:
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '9'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -11,17 +13,19 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '9'
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7
 fftw:
 - '3'
 fontconfig:
 - '2.13'
 freetype:
-- 2.9.1
+- '2'
 giflib:
 - '5.2'
+glib:
+- '2.58'
 graphviz:
 - '2.40'
 jpeg:
@@ -77,5 +81,8 @@ target_platform:
 - linux-64
 xz:
 - '5.2'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1.2'

--- a/.ci_support/migrations/glib2646.yaml
+++ b/.ci_support/migrations/glib2646.yaml
@@ -1,0 +1,15 @@
+migrator_ts: 1
+__migrator:
+  kind:
+    version
+  migration_number:
+    1
+  build_number:
+    1
+
+glib:
+  - 2.64.6  # [not (osx and arm64)]
+  - 2.66    # [osx and arm64]
+libglib:
+  - 2.64.6  # [not (osx and arm64)]
+  - 2.66    # [osx and arm64]

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -23,7 +23,7 @@ freetype:
 giflib:
 - '5.2'
 glib:
-- '2.58'
+- 2.64.6
 graphviz:
 - '2.40'
 jpeg:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -5,7 +5,7 @@ bzip2:
 c_compiler:
 - clang
 c_compiler_version:
-- '10'
+- '11'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -13,15 +13,17 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '10'
+- '11'
 fftw:
 - '3'
 fontconfig:
 - '2.13'
 freetype:
-- 2.9.1
+- '2'
 giflib:
 - '5.2'
+glib:
+- '2.58'
 graphviz:
 - '2.40'
 jpeg:
@@ -38,8 +40,6 @@ libxml2:
 - '2.9'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
 openjpeg:
 - '2.3'
 pango:
@@ -81,5 +81,8 @@ target_platform:
 - osx-64
 xz:
 - '5.2'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1.2'

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -74,6 +74,8 @@ docker run ${DOCKER_RUN_ARGS} \
            -e CI \
            -e FEEDSTOCK_NAME \
            -e CPU_COUNT \
+           -e BUILD_WITH_CONDA_DEBUG \
+           -e BUILD_OUTPUT_ID \
            -e BINSTAR_TOKEN \
            -e FEEDSTOCK_TOKEN \
            -e STAGING_BINSTAR_TOKEN \

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -23,7 +23,7 @@ source ${HOME}/miniforge3/etc/profile.d/conda.sh
 conda activate base
 
 echo -e "\n\nInstalling conda-forge-ci-setup=3 and conda-build."
-conda install -n base --quiet --yes conda-forge-ci-setup=3 conda-build pip
+conda install -n base --quiet --yes "conda-forge-ci-setup=3" conda-build pip
 
 
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,9 @@ Home: http://www.imagemagick.org/
 
 Package license: ImageMagick
 
-Feedstock license: BSD-3-Clause
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/imagemagick-feedstock/blob/master/LICENSE.txt)
 
 Summary: Software suite to create, edit, compose, or convert bitmap images.
-
-
 
 Current build status
 ====================

--- a/build-locally.py
+++ b/build-locally.py
@@ -12,6 +12,10 @@ from argparse import ArgumentParser
 def setup_environment(ns):
     os.environ["CONFIG"] = ns.config
     os.environ["UPLOAD_PACKAGES"] = "False"
+    if ns.debug:
+        os.environ["BUILD_WITH_CONDA_DEBUG"] = "1"
+        if ns.output_id:
+            os.environ["BUILD_OUTPUT_ID"] = ns.output_id
 
 
 def run_docker_build(ns):
@@ -51,6 +55,14 @@ def verify_config(ns):
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--debug",
+        action="store_true",
+        help="Setup debug environment using `conda debug`",
+    )
+    p.add_argument(
+        "--output-id", help="If running debug, specify the output to setup."
+    )
 
     ns = p.parse_args(args=args)
     verify_config(ns)

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -52,7 +52,8 @@ find $PREFIX -name '*.la' -delete
             --with-wmf=no \
             --with-x=yes \
             --with-xml=yes \
-            --with-zlib=yes
+            --with-zlib=yes \
+            --with-glib=yes
 
 make -j$CPU_COUNT
 # FIXME:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 9f2b8b131222354b196c640fca4e53eb0bbf62246621b9d467f223366272d7a7
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 9f2b8b131222354b196c640fca4e53eb0bbf62246621b9d467f223366272d7a7
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,7 @@ requirements:
     - xorg-libxt
     - xz
     - zlib
+    - glib
   run:
     - bzip2
     - fftw


### PR DESCRIPTION
Closes #146 
Similar to #161 but I applied the migration of glib because old glib was giving me problems in https://github.com/conda-forge/libvips-feedstock/pull/20


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
