### PR TITLE
Relaxing perl version requirements

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -44,8 +44,6 @@ openjpeg:
 - '2.4'
 pango:
 - '1.42'
-perl:
-- 5.26.2
 pin_run_as_build:
   bzip2:
     max_pin: x
@@ -71,8 +69,6 @@ pin_run_as_build:
     max_pin: x.x
   pango:
     max_pin: x.x
-  perl:
-    max_pin: x.x.x
   xz:
     max_pin: x.x
   zlib:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -44,8 +44,6 @@ openjpeg:
 - '2.4'
 pango:
 - '1.42'
-perl:
-- 5.26.2
 pin_run_as_build:
   bzip2:
     max_pin: x
@@ -71,8 +69,6 @@ pin_run_as_build:
     max_pin: x.x
   pango:
     max_pin: x.x
-  perl:
-    max_pin: x.x.x
   xz:
     max_pin: x.x
   zlib:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 936959ba77bb9d8fdab4d9c69f90316c02a7e2467dea3790ad36b4d500c31a22
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:
@@ -35,7 +35,7 @@ requirements:
     - libxml2
     - openjpeg
     - pango
-    - perl
+    - perl *
     - pkg-config
     - xorg-libx11
     - xorg-libxext
@@ -62,7 +62,7 @@ requirements:
     - libxml2
     - openjpeg
     - pango
-    - perl
+    - perl *
     - pkg-config
     - xorg-libx11
     - xorg-libxext


### PR DESCRIPTION
I would like to propose relaxing the perl dependency as it is currently pinned to 5.26.2.
My intention is to perform a migration of imagemagick for `osx-arm64` as soon as the next release of ghostscript (including osx-arm64 support) is available.
In order to perform migration relaxing the perl dependency is required as only `pearl=5.32.0` has been build for `osx-arm64`.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
