### PR TITLE
Remove perl dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,6 @@ requirements:
     - libxml2
     - openjpeg
     - pango
-    - perl *
     - xorg-libx11
     - xorg-libxext
     - xorg-libxrender
@@ -71,7 +70,6 @@ requirements:
     - libxml2
     - openjpeg
     - pango
-    - perl *
     - pkg-config
     - xorg-libx11
     - xorg-libxext


### PR DESCRIPTION
Since the support for bulding the perl bindings was removed in 2019 in #50, we can remove the perl dependency, which was probably forgotten to be removed.

Fixes: #340

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
